### PR TITLE
Const-qualifies fmt argument in cyaml__log()

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -129,7 +129,7 @@ static inline const char * cyaml__type_to_str(cyaml_type_e type)
 static inline void cyaml__log(
 		const cyaml_config_t *cfg,
 		cyaml_log_t level,
-		char *fmt, ...)
+		const char *fmt, ...)
 {
 	if (level >= cfg->log_level && cfg->log_fn != NULL) {
 		va_list args;


### PR DESCRIPTION
Addresses issue #140. The logging callback declares `fmt` [const-qualified as well](https://github.com/tlsa/libcyaml/blob/eda1ae8caf27bddeb39bd0dd34763daa641bdadc/include/cyaml/cyaml.h#L1331).